### PR TITLE
Support later GHC versions

### DIFF
--- a/System/Remote/Monitoring/ElasticSearch.hs
+++ b/System/Remote/Monitoring/ElasticSearch.hs
@@ -30,7 +30,6 @@ import           Control.Concurrent    (ThreadId, forkIO, threadDelay)
 import           Control.Exception     (catch)
 import           Control.Lens
 import           Control.Monad         (forever, void)
-import           Data.Default.Class    (def)
 import qualified Data.HashMap.Strict   as M
 import           Data.Int              (Int64)
 import           Data.Monoid           ((<>))
@@ -197,7 +196,7 @@ flushSample store eo = do
   createBulk <- mkIndex eo
   bulkEvts <- sampleBeatEvents store eo
   let body = ReqBodyLbs . bulkRequestBody . BulkRequest $ (createBulk, ) <$> bulkEvts
-  (void . runReq def $ Req.req POST
+  (void . runReq Req.defaultHttpConfig $ Req.req POST
     (elasticURL eo)
     body
     Req.ignoreResponse

--- a/ekg-elasticsearch.cabal
+++ b/ekg-elasticsearch.cabal
@@ -19,17 +19,16 @@ library
     System.Remote.Monitoring.ElasticSearch
     System.Metrics.Json
 
-  build-depends: base >= 4.5 && < 4.11
+  build-depends: base >= 4.5 && < 5
                , bytestring < 1.0
-               , data-default-class
                , ekg-core >= 0.1 && < 1.0
-               , aeson >= 1.0
+               , aeson >= 1.0 && < 2
                , hostname >= 1.0
                , http-client >= 0.5
                , lens >= 4.15.1
-               , req >= 1.0
+               , req >= 2.0 && < 4
                , text < 1.3
-               , time < 1.9
+               , time >= 1.0 && <2
                , unordered-containers < 0.3
 
   default-language:    Haskell2010


### PR DESCRIPTION
### Why upgrade `req`?

The currect code uses a `Default` instance for `HttpConfig`, which is only available in `req` >=1.0 && <= 1.2.1.
This effectively pins `retry` at 0.7.*,
which requires `ghc-prim` < 0.6, but later versions of `base` require greater versions of `ghc-prim`.

### Why relax `time` bounds?

Time required an old `TemplateHaskell`, which required an old `base`.

### Why pin `aeson` to < 2?

Because this package doesn't suport `aeson` >= 2, and fails to build it a greater version is chosen.