### PR TITLE
Upgrade to aeson >= 2.0

### DIFF
--- a/ekg-elasticsearch.cabal
+++ b/ekg-elasticsearch.cabal
@@ -23,7 +23,7 @@ library
                , bytestring < 1.0
                , data-default-class
                , ekg-core >= 0.1 && < 1.0
-               , aeson >= 1.0
+               , aeson >= 2.0
                , hostname >= 1.0
                , http-client >= 0.5
                , lens >= 4.15.1


### PR DESCRIPTION
Aeson 2.0 introduced some breaking changes, mainly the opaque
`KeyMap` datatype. Aeson 2.0 was released in October 2021, and I think
it's time to upgrade.

I've made sure that these changes built, but only alongside the changes from my
[os/ghc-9.0](https://github.com/414owen/ekg-elasticsearch/tree/os/ghc-9.0) branch, as I don't have a ghc 8.x installation at the moment.
